### PR TITLE
[BEAM-4360]  Migration of ReduceByKey test suite

### DIFF
--- a/sdks/java/extensions/euphoria/euphoria-beam/build.gradle
+++ b/sdks/java/extensions/euphoria/euphoria-beam/build.gradle
@@ -13,11 +13,9 @@ dependencies {
     shadow 'com.google.code.findbugs:annotations:3.0.1'
     testCompile project(':beam-sdks-java-extensions-euphoria-operator-testkit')
     testCompile project(':beam-sdks-java-extensions-euphoria-testing')
-    //testCompile project(':beam-runners-direct-java')
+    testCompile project(':beam-runners-direct-java')
     testCompile library.java.slf4j_api
     testCompile library.java.hamcrest_core
-    testCompile "org.apache.beam:beam-runners-direct-java:2.4.0"
-
 }
 
 test.testLogging.showStandardStreams = true

--- a/sdks/java/extensions/euphoria/euphoria-beam/build.gradle
+++ b/sdks/java/extensions/euphoria/euphoria-beam/build.gradle
@@ -13,9 +13,10 @@ dependencies {
     shadow 'com.google.code.findbugs:annotations:3.0.1'
     testCompile project(':beam-sdks-java-extensions-euphoria-operator-testkit')
     testCompile project(':beam-sdks-java-extensions-euphoria-testing')
-    testCompile project(':beam-runners-direct-java')
+    //testCompile project(':beam-runners-direct-java')
     testCompile library.java.slf4j_api
     testCompile library.java.hamcrest_core
+    testCompile "org.apache.beam:beam-runners-direct-java:2.4.0"
 
 }
 

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/FlowTranslator.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/FlowTranslator.java
@@ -20,6 +20,7 @@ import cz.seznam.euphoria.core.client.accumulators.AccumulatorProvider;
 import cz.seznam.euphoria.core.client.flow.Flow;
 import cz.seznam.euphoria.core.client.io.DataSink;
 import cz.seznam.euphoria.core.client.operator.FlatMap;
+import cz.seznam.euphoria.core.client.operator.Join;
 import cz.seznam.euphoria.core.client.operator.Operator;
 import cz.seznam.euphoria.core.client.operator.ReduceByKey;
 import cz.seznam.euphoria.core.client.operator.ReduceStateByKey;
@@ -52,7 +53,7 @@ class FlowTranslator {
     // extended operators
     translators.put(ReduceByKey.class, new ReduceByKeyTranslator());
     translators.put(ReduceStateByKey.class, new ReduceStateByKeyTranslator());
-    translators.put(JoinTranslator.class, new JoinTranslator());
+    translators.put(Join.class, new JoinTranslator());
   }
 
   static Pipeline toPipeline(

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/FlowTranslator.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/FlowTranslator.java
@@ -52,6 +52,7 @@ class FlowTranslator {
     // extended operators
     translators.put(ReduceByKey.class, new ReduceByKeyTranslator());
     translators.put(ReduceStateByKey.class, new ReduceStateByKeyTranslator());
+    translators.put(JoinTranslator.class, new JoinTranslator());
   }
 
   static Pipeline toPipeline(

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/JoinTranslator.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/JoinTranslator.java
@@ -1,9 +1,24 @@
 package cz.seznam.euphoria.beam;
 
+import cz.seznam.euphoria.beam.io.KryoCoder;
+import cz.seznam.euphoria.beam.join.InnerJoinFn;
+import cz.seznam.euphoria.beam.common.InputToKvDoFn;
+import cz.seznam.euphoria.beam.join.JoinFn;
+import cz.seznam.euphoria.beam.window.WindowingUtils;
 import cz.seznam.euphoria.core.client.dataset.windowing.Window;
+import cz.seznam.euphoria.core.client.functional.UnaryFunction;
 import cz.seznam.euphoria.core.client.operator.Join;
+import cz.seznam.euphoria.core.client.util.Pair;
+import java.util.List;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.join.CoGbkResult;
+import org.apache.beam.sdk.transforms.join.CoGroupByKey;
+import org.apache.beam.sdk.transforms.join.KeyedPCollectionTuple;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TupleTag;
 
 public class JoinTranslator implements OperatorTranslator<Join> {
 
@@ -14,12 +29,76 @@ public class JoinTranslator implements OperatorTranslator<Join> {
   }
 
 
-  public <K, LeftT, RightT, OutputT, W extends Window<W>> PCollection<KV<K, KV<LeftT, RightT>>>
-    doTranslate(Join<LeftT, RightT, K, OutputT, W> operator, BeamExecutorContext context) {
+  public <K, LeftT, RightT, OutputT, W extends Window<W>> PCollection<Pair<K, OutputT>>
+  doTranslate(Join<LeftT, RightT, K, OutputT, W> operator, BeamExecutorContext context) {
 
+    Coder<K> keyCoder = context.getCoder(operator.getLeftKeyExtractor());
 
+    // get input data-sets transformed to Pcollections<KV<K,LeftT/RightT>>
+    List<PCollection<Object>> inputs = context.getInputs(operator);
 
+    //TODO test left/right side indexes !
+    PCollection<KV<K, LeftT>> leftKvInput = getKVInputCollection(inputs.get(0),
+        operator.getLeftKeyExtractor(),
+        keyCoder, new KryoCoder<>(), "::extract-keys-left");
 
-    throw new UnsupportedOperationException("Not supported yet");
+    PCollection<KV<K, RightT>> rightKvInput = getKVInputCollection(inputs.get(1),
+        operator.getRightKeyExtractor(),
+        keyCoder, new KryoCoder<>(), "::extract-keys-right");
+
+    // GoGroupByKey collections
+    TupleTag<LeftT> leftTag = new TupleTag<>();
+    TupleTag<RightT> rightTag = new TupleTag<>();
+
+    PCollection<KV<K, CoGbkResult>> coGrouped = KeyedPCollectionTuple
+        .of(leftTag, leftKvInput)
+        .and(rightTag, rightKvInput)
+        .apply("::co-group-by-key", CoGroupByKey.create());
+
+    coGrouped = WindowingUtils
+        .applyWindowingIfSpecified(operator, coGrouped, context.getAllowedLateness(operator));
+
+    // Join
+    JoinFn<LeftT, RightT, K, OutputT> joinFn = chooseJoinFn(operator, leftTag, rightTag);
+
+    return coGrouped.apply(joinFn.getFnName(), ParDo.of(joinFn));
+  }
+
+  private <K, ValueT> PCollection<KV<K, ValueT>> getKVInputCollection(
+      PCollection<Object> inputPCollection,
+      UnaryFunction<ValueT, K> keyExtractor,
+      Coder<K> keyCoder, Coder<ValueT> valueCoder, String transformName) {
+
+    @SuppressWarnings("unchecked")
+    PCollection<ValueT> typedInput = (PCollection<ValueT>) inputPCollection;
+    typedInput.setCoder(valueCoder);
+
+    PCollection<KV<K, ValueT>> leftKvInput =
+        typedInput.apply(transformName, ParDo.of(new InputToKvDoFn<>(keyExtractor)));
+    leftKvInput.setCoder(KvCoder.of(keyCoder, valueCoder));
+
+    return leftKvInput;
+  }
+
+  private <K, LeftT, RightT, OutputT, W extends Window<W>> JoinFn<LeftT, RightT, K, OutputT> chooseJoinFn(
+
+      Join<LeftT, RightT, K, OutputT, W> operator, TupleTag<LeftT> leftTag,
+      TupleTag<RightT> rightTag) {
+    // choose right ParDo to do LEFT, RIGHT, INNER or OUTER join
+    JoinFn<LeftT, RightT, K, OutputT> joinFn;
+    switch (operator.getType()) {
+      case INNER:
+        joinFn = new InnerJoinFn<>(operator.getJoiner(), leftTag, rightTag);
+        break;
+      case RIGHT:
+      case LEFT:
+      case FULL:
+      default:
+        throw new UnsupportedOperationException(String.format(
+            "Cannot translate Euphoria '%s' operator to Beam transformations."
+                + " Given join type '%s' is not supported.",
+            Join.class.getSimpleName(), operator.getType()));
+    }
+    return joinFn;
   }
 }

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/JoinTranslator.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/JoinTranslator.java
@@ -1,0 +1,25 @@
+package cz.seznam.euphoria.beam;
+
+import cz.seznam.euphoria.core.client.dataset.windowing.Window;
+import cz.seznam.euphoria.core.client.operator.Join;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+
+public class JoinTranslator implements OperatorTranslator<Join> {
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public PCollection<?> translate(Join operator, BeamExecutorContext context) {
+    return doTranslate(operator, context);
+  }
+
+
+  public <K, LeftT, RightT, OutputT, W extends Window<W>> PCollection<KV<K, KV<LeftT, RightT>>>
+    doTranslate(Join<LeftT, RightT, K, OutputT, W> operator, BeamExecutorContext context) {
+
+
+
+
+    throw new UnsupportedOperationException("Not supported yet");
+  }
+}

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/JoinTranslator.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/JoinTranslator.java
@@ -1,8 +1,8 @@
 package cz.seznam.euphoria.beam;
 
+import cz.seznam.euphoria.beam.common.InputToKvDoFn;
 import cz.seznam.euphoria.beam.io.KryoCoder;
 import cz.seznam.euphoria.beam.join.InnerJoinFn;
-import cz.seznam.euphoria.beam.common.InputToKvDoFn;
 import cz.seznam.euphoria.beam.join.JoinFn;
 import cz.seznam.euphoria.beam.window.WindowingUtils;
 import cz.seznam.euphoria.core.client.dataset.windowing.Window;
@@ -20,6 +20,10 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TupleTag;
 
+
+/**
+ * {@link OperatorTranslator Translator } for Euphoria {@link Join} operator.
+ */
 public class JoinTranslator implements OperatorTranslator<Join> {
 
   @Override
@@ -80,11 +84,11 @@ public class JoinTranslator implements OperatorTranslator<Join> {
     return leftKvInput;
   }
 
-  private <K, LeftT, RightT, OutputT, W extends Window<W>> JoinFn<LeftT, RightT, K, OutputT> chooseJoinFn(
-
+  private <K, LeftT, RightT, OutputT, W extends Window<W>> JoinFn<LeftT, RightT, K, OutputT>
+  chooseJoinFn(
       Join<LeftT, RightT, K, OutputT, W> operator, TupleTag<LeftT> leftTag,
       TupleTag<RightT> rightTag) {
-    // choose right ParDo to do LEFT, RIGHT, INNER or OUTER join
+
     JoinFn<LeftT, RightT, K, OutputT> joinFn;
     switch (operator.getType()) {
       case INNER:

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/ReduceByKeyTranslator.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/ReduceByKeyTranslator.java
@@ -15,10 +15,9 @@
  */
 package cz.seznam.euphoria.beam;
 
-import cz.seznam.euphoria.beam.window.BeamWindowing;
+import cz.seznam.euphoria.beam.window.WindowingUtils;
 import cz.seznam.euphoria.core.client.accumulators.AccumulatorProvider;
 import cz.seznam.euphoria.core.client.dataset.windowing.Window;
-import cz.seznam.euphoria.core.client.dataset.windowing.Windowing;
 import cz.seznam.euphoria.core.client.functional.ReduceFunctor;
 import cz.seznam.euphoria.core.client.functional.UnaryFunction;
 import cz.seznam.euphoria.core.client.operator.ReduceByKey;
@@ -54,8 +53,8 @@ class ReduceByKeyTranslator implements OperatorTranslator<ReduceByKey> {
     final Coder<K> keyCoder = context.getCoder(keyExtractor);
     final Coder<V> valueCoder = context.getCoder(valueExtractor);
 
-    final PCollection<InputT> input = applyWindowingIfSpecified(operator,
-        context.getInput(operator), context);
+    final PCollection<InputT> input = WindowingUtils.applyWindowingIfSpecified(operator,
+        context.getInput(operator), context.getAllowedLateness(operator));
 
     // ~ create key & value extractor
     final MapElements<InputT, KV<K, V>> extractor =
@@ -99,48 +98,6 @@ class ReduceByKeyTranslator implements OperatorTranslator<ReduceByKey> {
       return grouped.apply(
           operator.getName() + "::reduce", ParDo.of(new ReduceDoFn<>(reducer, accumulators)));
     }
-  }
-
-  private static <InputT, K, V, OutputT, W extends Window<W>>
-  PCollection<InputT> applyWindowingIfSpecified(
-      ReduceByKey<InputT, K, V, OutputT, W> operator, PCollection<InputT> input,
-      BeamExecutorContext context) {
-
-    Windowing<InputT, W> userSpecifiedWindowing = operator.getWindowing();
-
-    if (userSpecifiedWindowing == null) {
-      return input;
-    }
-
-    if (!(userSpecifiedWindowing instanceof BeamWindowing)) {
-      throw new IllegalStateException(String.format(
-          "%s class only is supported to specify windowing.", BeamWindowing.class.getSimpleName()));
-    }
-
-    @SuppressWarnings("unchecked")
-    BeamWindowing<InputT, ?> beamWindowing = (BeamWindowing) userSpecifiedWindowing;
-
-    @SuppressWarnings("unchecked")
-    org.apache.beam.sdk.transforms.windowing.Window<InputT> beamWindow =
-        (org.apache.beam.sdk.transforms.windowing.Window<InputT>)
-            org.apache.beam.sdk.transforms.windowing.Window.into(beamWindowing.getWindowFn())
-                .triggering(beamWindowing.getBeamTrigger());
-
-    switch (beamWindowing.getAccumulationMode()) {
-      case DISCARDING_FIRED_PANES:
-        beamWindow = beamWindow.discardingFiredPanes();
-        break;
-      case ACCUMULATING_FIRED_PANES:
-        beamWindow = beamWindow.accumulatingFiredPanes();
-        break;
-      default:
-        throw new IllegalStateException(
-            "Unsupported accumulation mode '" + beamWindowing.getAccumulationMode() + "'");
-    }
-
-    beamWindow = beamWindow.withAllowedLateness(context.getAllowedLateness(operator));
-
-    return input.apply(operator.getName() + "::windowing", beamWindow);
   }
 
   private static <InputT, OutputT> SerializableFunction<Iterable<InputT>, InputT> asCombiner(

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/ReduceByKeyTranslator.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/ReduceByKeyTranslator.java
@@ -45,6 +45,10 @@ class ReduceByKeyTranslator implements OperatorTranslator<ReduceByKey> {
   private static <InputT, K, V, OutputT, W extends Window<W>> PCollection<Pair<K, OutputT>>
   doTranslate(ReduceByKey<InputT, K, V, OutputT, W> operator, BeamExecutorContext context) {
 
+    if (operator.getValueComparator() != null) { //TODO Could we even do values sorting ?
+      throw new UnsupportedOperationException("Values sorting is not supported.");
+    }
+
     final UnaryFunction<InputT, K> keyExtractor = operator.getKeyExtractor();
     final UnaryFunction<InputT, V> valueExtractor = operator.getValueExtractor();
     final ReduceFunctor<V, OutputT> reducer = operator.getReducer();

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/ReduceStateByKeyTranslator.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/ReduceStateByKeyTranslator.java
@@ -63,6 +63,6 @@ public class ReduceStateByKeyTranslator implements OperatorTranslator<ReduceStat
           .setCoder(new KryoCoder<>());
     }
     */
-    throw new UnsupportedOperationException("Not supported yet");
+    throw new UnsupportedOperationException("ReduceStateByKy is not supported yet.");
   }
 }

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/common/InputToKvDoFn.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/common/InputToKvDoFn.java
@@ -1,0 +1,22 @@
+package cz.seznam.euphoria.beam.common;
+
+import cz.seznam.euphoria.core.client.functional.UnaryFunction;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.values.KV;
+
+public class InputToKvDoFn<InputT, K> extends DoFn<InputT, KV<K, InputT>> {
+
+  private final UnaryFunction<InputT, K> keyExtractor;
+
+  public InputToKvDoFn(UnaryFunction<InputT, K> leftKeyExtractor) {
+    this.keyExtractor = leftKeyExtractor;
+  }
+
+  @ProcessElement
+  public void processElement(ProcessContext c) {
+    InputT element = c.element();
+    K key = keyExtractor.apply(element);
+    c.output(KV.of(key, element));
+  }
+
+}

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/common/InputToKvDoFn.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/common/InputToKvDoFn.java
@@ -4,6 +4,10 @@ import cz.seznam.euphoria.core.client.functional.UnaryFunction;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.values.KV;
 
+/**
+ * {@link DoFn} which takes input elements and transforms them to {@link KV} using given key
+ * extractor.
+ */
 public class InputToKvDoFn<InputT, K> extends DoFn<InputT, KV<K, InputT>> {
 
   private final UnaryFunction<InputT, K> keyExtractor;

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/common/package-info.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/common/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A set of commonly used classes enabling some code reuse.
+ */
+package cz.seznam.euphoria.beam.common;

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/join/FullJoinFn.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/join/FullJoinFn.java
@@ -1,0 +1,60 @@
+package cz.seznam.euphoria.beam.join;
+
+import cz.seznam.euphoria.beam.SingleValueCollector;
+import cz.seznam.euphoria.core.client.functional.BinaryFunctor;
+import cz.seznam.euphoria.core.client.util.Pair;
+import org.apache.beam.sdk.transforms.join.CoGbkResult;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.TupleTag;
+
+/**
+ * Full join implementation of {@link JoinFn}.
+ */
+public class FullJoinFn<LeftT, RightT, K, OutputT> extends JoinFn<LeftT, RightT, K, OutputT> {
+
+  public FullJoinFn(BinaryFunctor<LeftT, RightT, OutputT> joiner, TupleTag<LeftT> leftTag,
+      TupleTag<RightT> rightTag) {
+    super(joiner, leftTag, rightTag);
+  }
+
+  @Override
+  public void processElement(ProcessContext c) {
+
+    KV<K, CoGbkResult> element = c.element();
+    CoGbkResult value = element.getValue();
+    K key = element.getKey();
+
+    Iterable<LeftT> leftSideIter = value.getAll(leftTag);
+    Iterable<RightT> rightSIdeIter = value.getAll(rightTag);
+
+    SingleValueCollector<OutputT> outCollector = new SingleValueCollector<>();
+
+    boolean leftHasValues = leftSideIter.iterator().hasNext();
+    boolean rightHasValues = rightSIdeIter.iterator().hasNext();
+
+    if (leftHasValues && rightHasValues) {
+      for (RightT rightValue : rightSIdeIter) {
+        for (LeftT leftValue : leftSideIter) {
+          joiner.apply(leftValue, rightValue, outCollector);
+          c.output(Pair.of(key, outCollector.get()));
+        }
+      }
+    } else if (leftHasValues && !rightHasValues) {
+      for (LeftT leftValue : leftSideIter) {
+        joiner.apply(leftValue, null, outCollector);
+        c.output(Pair.of(key, outCollector.get()));
+      }
+    } else if (!leftHasValues && rightHasValues) {
+      for (RightT rightValue : rightSIdeIter) {
+        joiner.apply(null, rightValue, outCollector);
+        c.output(Pair.of(key, outCollector.get()));
+      }
+    }
+
+  }
+
+  @Override
+  public String getFnName() {
+    return "::full-join";
+  }
+}

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/join/InnerJoinFn.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/join/InnerJoinFn.java
@@ -7,6 +7,9 @@ import org.apache.beam.sdk.transforms.join.CoGbkResult;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.TupleTag;
 
+/**
+ * Inner join implementation of {@link JoinFn}.
+ */
 public class InnerJoinFn<LeftT, RightT, K, OutputT> extends JoinFn<LeftT, RightT, K, OutputT> {
 
   public InnerJoinFn(

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/join/InnerJoinFn.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/join/InnerJoinFn.java
@@ -1,0 +1,44 @@
+package cz.seznam.euphoria.beam.join;
+
+import cz.seznam.euphoria.beam.SingleValueCollector;
+import cz.seznam.euphoria.core.client.functional.BinaryFunctor;
+import cz.seznam.euphoria.core.client.util.Pair;
+import org.apache.beam.sdk.transforms.join.CoGbkResult;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.TupleTag;
+
+public class InnerJoinFn<LeftT, RightT, K, OutputT> extends JoinFn<LeftT, RightT, K, OutputT> {
+
+  public InnerJoinFn(
+      BinaryFunctor<LeftT, RightT, OutputT> functor,
+      TupleTag<LeftT> leftTag,
+      TupleTag<RightT> rightTag) {
+    super(functor, leftTag, rightTag);
+  }
+
+  @Override
+  public void processElement(ProcessContext c) {
+
+    KV<K, CoGbkResult> element = c.element();
+    CoGbkResult value = element.getValue();
+    K key = element.getKey();
+
+    Iterable<LeftT> leftSideIter = value.getAll(leftTag);
+    Iterable<RightT> rightSideIter = value.getAll(rightTag);
+
+    SingleValueCollector<OutputT> outCollector = new SingleValueCollector<>();
+
+    for (LeftT leftItem : leftSideIter) {
+      for (RightT rightItem : rightSideIter) {
+        joiner.apply(leftItem, rightItem, outCollector);
+        c.output(Pair.of(key, outCollector.get()));
+      }
+    }
+  }
+
+  @Override
+  public String getFnName() {
+    return "::inner-join";
+  }
+
+}

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/join/JoinFn.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/join/JoinFn.java
@@ -7,7 +7,16 @@ import org.apache.beam.sdk.transforms.join.CoGbkResult;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.TupleTag;
 
-public abstract class JoinFn<LeftT, RightT, K, OutputT> extends DoFn<KV<K, CoGbkResult>, Pair<K, OutputT>> {
+/**
+ * Abstract base for joint implementations.
+ *
+ * @param <LeftT> type of left-side elements
+ * @param <RightT> type of right-side elements
+ * @param <K> key type
+ * @param <OutputT> type of output elements
+ */
+public abstract class JoinFn<LeftT, RightT, K, OutputT> extends
+    DoFn<KV<K, CoGbkResult>, Pair<K, OutputT>> {
 
   protected final BinaryFunctor<LeftT, RightT, OutputT> joiner;
   protected final TupleTag<LeftT> leftTag;
@@ -24,5 +33,5 @@ public abstract class JoinFn<LeftT, RightT, K, OutputT> extends DoFn<KV<K, CoGbk
   @ProcessElement
   public abstract void processElement(ProcessContext c);
 
-  public  abstract String getFnName();
+  public abstract String getFnName();
 }

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/join/JoinFn.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/join/JoinFn.java
@@ -1,0 +1,28 @@
+package cz.seznam.euphoria.beam.join;
+
+import cz.seznam.euphoria.core.client.functional.BinaryFunctor;
+import cz.seznam.euphoria.core.client.util.Pair;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.join.CoGbkResult;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.TupleTag;
+
+public abstract class JoinFn<LeftT, RightT, K, OutputT> extends DoFn<KV<K, CoGbkResult>, Pair<K, OutputT>> {
+
+  protected final BinaryFunctor<LeftT, RightT, OutputT> joiner;
+  protected final TupleTag<LeftT> leftTag;
+  protected final TupleTag<RightT> rightTag;
+
+  protected JoinFn(
+      BinaryFunctor<LeftT, RightT, OutputT> joiner,
+      TupleTag<LeftT> leftTag, TupleTag<RightT> rightTag) {
+    this.joiner = joiner;
+    this.leftTag = leftTag;
+    this.rightTag = rightTag;
+  }
+
+  @ProcessElement
+  public abstract void processElement(ProcessContext c);
+
+  public  abstract String getFnName();
+}

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/join/LeftJoinFn.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/join/LeftJoinFn.java
@@ -1,12 +1,15 @@
 package cz.seznam.euphoria.beam.join;
-
+/*
 import cz.seznam.euphoria.beam.SingleValueCollector;
 import cz.seznam.euphoria.core.client.functional.BinaryFunctor;
 import org.apache.beam.sdk.transforms.join.CoGbkResult;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.TupleTag;
+*/
 
-//TODO implement
+/**
+ * Left Join implementation of {@link JoinFn}.
+ */
 public class LeftJoinFn<LeftT, RightT, K, OutputT> /*extends JoinFn<LeftT, RightT, K, OutputT> */{
 /*
   protected LeftJoinFn(

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/join/LeftJoinFn.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/join/LeftJoinFn.java
@@ -1,0 +1,38 @@
+package cz.seznam.euphoria.beam.join;
+
+import cz.seznam.euphoria.beam.SingleValueCollector;
+import cz.seznam.euphoria.core.client.functional.BinaryFunctor;
+import org.apache.beam.sdk.transforms.join.CoGbkResult;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.TupleTag;
+
+//TODO implement
+public class LeftJoinFn<LeftT, RightT, K, OutputT> /*extends JoinFn<LeftT, RightT, K, OutputT> */{
+/*
+  protected LeftJoinFn(
+      BinaryFunctor<LeftT, RightT, OutputT> joiner,
+      TupleTag<LeftT> leftTag,
+      TupleTag<RightT> rightTag) {
+    super(joiner, leftTag, rightTag);
+  }
+
+  @Override
+  public void processElement(ProcessContext c) {
+
+    KV<K, CoGbkResult> element = c.element();
+    CoGbkResult value = element.getValue();
+
+    Iterable<LeftT> leftSideIter = value.getAll(leftTag);
+    Iterable<RightT> rightSIdeIter = value.getAll(rightTag);
+
+    SingleValueCollector<OutputT> outCollector = new SingleValueCollector<>();
+
+
+  }
+
+  @Override
+  public String getFnName() {
+    return "::left-join";
+  }
+  */
+}

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/join/LeftOuterJoinFn.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/join/LeftOuterJoinFn.java
@@ -1,0 +1,55 @@
+package cz.seznam.euphoria.beam.join;
+
+import cz.seznam.euphoria.beam.SingleValueCollector;
+import cz.seznam.euphoria.core.client.functional.BinaryFunctor;
+import cz.seznam.euphoria.core.client.util.Pair;
+import org.apache.beam.sdk.transforms.join.CoGbkResult;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.TupleTag;
+
+
+/**
+ * Left outer join implementation of {@link JoinFn}.
+ */
+public class LeftOuterJoinFn<LeftT, RightT, K, OutputT> extends JoinFn<LeftT, RightT, K, OutputT> {
+
+  public LeftOuterJoinFn(
+      BinaryFunctor<LeftT, RightT, OutputT> joiner,
+      TupleTag<LeftT> leftTag,
+      TupleTag<RightT> rightTag) {
+    super(joiner, leftTag, rightTag);
+  }
+
+  @Override
+  public void processElement(ProcessContext c) {
+
+    KV<K, CoGbkResult> element = c.element();
+    CoGbkResult value = element.getValue();
+    K key = element.getKey();
+
+    Iterable<LeftT> leftSideIter = value.getAll(leftTag);
+    Iterable<RightT> rightSIdeIter = value.getAll(rightTag);
+
+    SingleValueCollector<OutputT> outCollector = new SingleValueCollector<>();
+
+    for (LeftT leftValue : leftSideIter) {
+      if (rightSIdeIter.iterator().hasNext()) {
+        for (RightT rightValue : rightSIdeIter) {
+          joiner.apply(leftValue, rightValue, outCollector);
+          c.output(Pair.of(key, outCollector.get()));
+        }
+      } else {
+          joiner.apply(leftValue, null, outCollector);
+          c.output(Pair.of(key, outCollector.get()));
+      }
+    }
+
+
+  }
+
+  @Override
+  public String getFnName() {
+    return "::left-outer-join";
+  }
+
+}

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/join/RightOuterJoinFn.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/join/RightOuterJoinFn.java
@@ -1,18 +1,18 @@
 package cz.seznam.euphoria.beam.join;
-/*
+
 import cz.seznam.euphoria.beam.SingleValueCollector;
 import cz.seznam.euphoria.core.client.functional.BinaryFunctor;
+import cz.seznam.euphoria.core.client.util.Pair;
 import org.apache.beam.sdk.transforms.join.CoGbkResult;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.TupleTag;
-*/
 
 /**
- * Left Join implementation of {@link JoinFn}.
+ * Right outer join implementation of {@link JoinFn}.
  */
-public class LeftJoinFn<LeftT, RightT, K, OutputT> /*extends JoinFn<LeftT, RightT, K, OutputT> */{
-/*
-  protected LeftJoinFn(
+public class RightOuterJoinFn<LeftT, RightT, K, OutputT> extends JoinFn<LeftT, RightT, K, OutputT> {
+
+  public RightOuterJoinFn(
       BinaryFunctor<LeftT, RightT, OutputT> joiner,
       TupleTag<LeftT> leftTag,
       TupleTag<RightT> rightTag) {
@@ -24,18 +24,29 @@ public class LeftJoinFn<LeftT, RightT, K, OutputT> /*extends JoinFn<LeftT, Right
 
     KV<K, CoGbkResult> element = c.element();
     CoGbkResult value = element.getValue();
+    K key = element.getKey();
 
     Iterable<LeftT> leftSideIter = value.getAll(leftTag);
     Iterable<RightT> rightSIdeIter = value.getAll(rightTag);
 
     SingleValueCollector<OutputT> outCollector = new SingleValueCollector<>();
 
+    for (RightT rightValue : rightSIdeIter) {
+      if (leftSideIter.iterator().hasNext()) {
+        for (LeftT leftValue : leftSideIter) {
+          joiner.apply(leftValue, rightValue, outCollector);
+          c.output(Pair.of(key, outCollector.get()));
+        }
+      } else {
+        joiner.apply(null, rightValue, outCollector);
+        c.output(Pair.of(key, outCollector.get()));
+      }
+    }
 
   }
 
   @Override
   public String getFnName() {
-    return "::left-join";
+    return "::right-outer-join";
   }
-  */
 }

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/join/package-info.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/join/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * {@link cz.seznam.euphoria.core.client.operator.Join} translation centered classes.
+ */
+package cz.seznam.euphoria.beam.join;

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/window/WindowingUtils.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/window/WindowingUtils.java
@@ -1,0 +1,53 @@
+package cz.seznam.euphoria.beam.window;
+
+import cz.seznam.euphoria.core.client.dataset.windowing.Window;
+import cz.seznam.euphoria.core.client.dataset.windowing.Windowing;
+import cz.seznam.euphoria.core.client.operator.WindowWiseOperator;
+import org.apache.beam.sdk.values.PCollection;
+import org.joda.time.Duration;
+
+public class WindowingUtils {
+
+  public static <InputT, OutputT, W extends Window<W>>
+  PCollection<InputT> applyWindowingIfSpecified(
+      WindowWiseOperator<?, ?, OutputT, W> operator,
+      PCollection<InputT> input,
+      Duration allowedLateness) {
+
+    Windowing<?, W> userSpecifiedWindowing = operator.getWindowing();
+
+    if (userSpecifiedWindowing == null) {
+      return input;
+    }
+
+    if (!(userSpecifiedWindowing instanceof BeamWindowing)) {
+      throw new IllegalStateException(String.format(
+          "%s class only is supported to specify windowing.", BeamWindowing.class.getSimpleName()));
+    }
+
+    @SuppressWarnings("unchecked")
+    BeamWindowing<InputT, ?> beamWindowing = (BeamWindowing) userSpecifiedWindowing;
+
+    @SuppressWarnings("unchecked")
+    org.apache.beam.sdk.transforms.windowing.Window<InputT> beamWindow =
+        (org.apache.beam.sdk.transforms.windowing.Window<InputT>)
+            org.apache.beam.sdk.transforms.windowing.Window.into(beamWindowing.getWindowFn())
+                .triggering(beamWindowing.getBeamTrigger());
+
+    switch (beamWindowing.getAccumulationMode()) {
+      case DISCARDING_FIRED_PANES:
+        beamWindow = beamWindow.discardingFiredPanes();
+        break;
+      case ACCUMULATING_FIRED_PANES:
+        beamWindow = beamWindow.accumulatingFiredPanes();
+        break;
+      default:
+        throw new IllegalStateException(
+            "Unsupported accumulation mode '" + beamWindowing.getAccumulationMode() + "'");
+    }
+
+    beamWindow = beamWindow.withAllowedLateness(allowedLateness);
+
+    return input.apply(operator.getName() + "::windowing", beamWindow);
+  }
+}

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/window/WindowingUtils.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/window/WindowingUtils.java
@@ -26,7 +26,8 @@ public class WindowingUtils {
 
     if (!(userSpecifiedWindowing instanceof BeamWindowing)) {
       throw new IllegalStateException(String.format(
-          "%s class only is supported to specify windowing.", BeamWindowing.class.getSimpleName()));
+          "Use of '%s' is only way supported to specify windowing.",
+          BeamWindowing.class.getSimpleName()));
     }
 
     @SuppressWarnings("unchecked")

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/window/WindowingUtils.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/cz/seznam/euphoria/beam/window/WindowingUtils.java
@@ -3,9 +3,13 @@ package cz.seznam.euphoria.beam.window;
 import cz.seznam.euphoria.core.client.dataset.windowing.Window;
 import cz.seznam.euphoria.core.client.dataset.windowing.Windowing;
 import cz.seznam.euphoria.core.client.operator.WindowWiseOperator;
+import org.apache.beam.sdk.transforms.windowing.WindowFn;
 import org.apache.beam.sdk.values.PCollection;
 import org.joda.time.Duration;
 
+/**
+ * Collection of method helpful when dealing with windowing translations.
+ */
 public class WindowingUtils {
 
   public static <InputT, OutputT, W extends Window<W>>
@@ -30,9 +34,9 @@ public class WindowingUtils {
 
     @SuppressWarnings("unchecked")
     org.apache.beam.sdk.transforms.windowing.Window<InputT> beamWindow =
-        (org.apache.beam.sdk.transforms.windowing.Window<InputT>)
-            org.apache.beam.sdk.transforms.windowing.Window.into(beamWindowing.getWindowFn())
-                .triggering(beamWindowing.getBeamTrigger());
+        org.apache.beam.sdk.transforms.windowing.Window
+            .into((WindowFn<InputT, ?>) beamWindowing.getWindowFn())
+            .triggering(beamWindowing.getBeamTrigger());
 
     switch (beamWindowing.getAccumulationMode()) {
       case DISCARDING_FIRED_PANES:

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/test/java/cz/seznam/euphoria/beam/JoinTest.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/test/java/cz/seznam/euphoria/beam/JoinTest.java
@@ -1,0 +1,82 @@
+package cz.seznam.euphoria.beam;
+
+import static java.util.Arrays.asList;
+
+import cz.seznam.euphoria.core.client.flow.Flow;
+import cz.seznam.euphoria.core.client.functional.BinaryFunctor;
+import cz.seznam.euphoria.core.client.io.ListDataSink;
+import cz.seznam.euphoria.core.client.io.ListDataSource;
+import cz.seznam.euphoria.core.client.operator.Join;
+import cz.seznam.euphoria.core.client.util.Pair;
+import cz.seznam.euphoria.testing.DatasetAssert;
+import org.junit.Test;
+
+/**
+ * Simple test suite for Join operator.
+ */
+public class JoinTest {
+
+  @Test
+  public void simpleInnerJoinTest() {
+    final Flow flow = Flow.create();
+
+    ListDataSource<Pair<Integer, String>> left =
+        ListDataSource.bounded(
+            asList(
+                Pair.of(1, "L v1"), Pair.of(1, "L v2"),
+                Pair.of(2, "L v1"), Pair.of(2, "L v2"),
+                Pair.of(3, "L v1")
+            ));
+
+    ListDataSource<Pair<Integer, Integer>> right =
+        ListDataSource.bounded(
+            asList(
+                Pair.of(1, 1), Pair.of(1, 10),
+                Pair.of(2, 20),
+                Pair.of(4, 40)
+            ));
+
+    ListDataSink<Pair<Integer, Pair<String, Integer>>> output = ListDataSink.get();
+
+    BinaryFunctor<Pair<Integer, String>, Pair<Integer, Integer>, Pair<String, Integer>> joiner =
+        (l, r, c) -> c.collect(Pair.of(l.getSecond(), r.getSecond()));
+
+    Join.of(flow.createInput(left), flow.createInput(right))
+        .by(Pair::getFirst, Pair::getFirst)
+        .using(joiner)
+        .output()
+        .persist(output);
+
+    BeamExecutor executor = TestUtils.createExecutor();
+    executor.execute(flow);
+
+    DatasetAssert.unorderedEquals(output.getOutputs(),
+        Pair.of(1, Pair.of("L v1", 1)), Pair.of(1, Pair.of("L v1", 10)),
+        Pair.of(1, Pair.of("L v2", 1)), Pair.of(1, Pair.of("L v2", 10)),
+
+        Pair.of(2, Pair.of("L v1", 20)), Pair.of(2, Pair.of("L v2", 20))
+    );
+
+  }
+
+//  public void someFutureTest() {
+//
+//    ListDataSource<Pair<Integer, String>> left =
+//        ListDataSource.unbounded(
+//            asList(
+//                Pair.of(1, "L v1"), Pair.of(1, "L v2"), Pair.of(1, "L v3"),
+//                Pair.of(2, "L v1"), Pair.of(2, "L v2"),
+//                Pair.of(3, "L v1")
+//            ));
+//
+//    ListDataSource<Pair<Integer, Integer>> right =
+//        ListDataSource.unbounded(
+//            asList(
+//                Pair.of(1, 1), Pair.of(1, 10),
+//                Pair.of(2, 20),
+//                Pair.of(3, 30), Pair.of(3, 300), Pair.of(3, 3000)
+//            ));
+//  }
+
+
+}

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/test/java/cz/seznam/euphoria/beam/JoinTest.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/test/java/cz/seznam/euphoria/beam/JoinTest.java
@@ -202,5 +202,5 @@ public class JoinTest {
     );
 
   }
-  
+
 }

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/test/java/cz/seznam/euphoria/beam/JoinTest.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/test/java/cz/seznam/euphoria/beam/JoinTest.java
@@ -6,9 +6,13 @@ import cz.seznam.euphoria.core.client.flow.Flow;
 import cz.seznam.euphoria.core.client.functional.BinaryFunctor;
 import cz.seznam.euphoria.core.client.io.ListDataSink;
 import cz.seznam.euphoria.core.client.io.ListDataSource;
+import cz.seznam.euphoria.core.client.operator.FullJoin;
 import cz.seznam.euphoria.core.client.operator.Join;
+import cz.seznam.euphoria.core.client.operator.LeftJoin;
+import cz.seznam.euphoria.core.client.operator.RightJoin;
 import cz.seznam.euphoria.core.client.util.Pair;
 import cz.seznam.euphoria.testing.DatasetAssert;
+import java.util.Optional;
 import org.junit.Test;
 
 /**
@@ -59,24 +63,144 @@ public class JoinTest {
 
   }
 
-//  public void someFutureTest() {
-//
-//    ListDataSource<Pair<Integer, String>> left =
-//        ListDataSource.unbounded(
-//            asList(
-//                Pair.of(1, "L v1"), Pair.of(1, "L v2"), Pair.of(1, "L v3"),
-//                Pair.of(2, "L v1"), Pair.of(2, "L v2"),
-//                Pair.of(3, "L v1")
-//            ));
-//
-//    ListDataSource<Pair<Integer, Integer>> right =
-//        ListDataSource.unbounded(
-//            asList(
-//                Pair.of(1, 1), Pair.of(1, 10),
-//                Pair.of(2, 20),
-//                Pair.of(3, 30), Pair.of(3, 300), Pair.of(3, 3000)
-//            ));
-//  }
+  @Test
+  public void simpleLeftJoinTest() {
+    final Flow flow = Flow.create();
 
+    ListDataSource<Pair<Integer, String>> left =
+        ListDataSource.bounded(
+            asList(
+                Pair.of(1, "L v1"), Pair.of(1, "L v2"),
+                Pair.of(2, "L v1"), Pair.of(2, "L v2"),
+                Pair.of(3, "L v1")
+            ));
 
+    ListDataSource<Pair<Integer, Integer>> right =
+        ListDataSource.bounded(
+            asList(
+                Pair.of(1, 1), Pair.of(1, 10),
+                Pair.of(2, 20),
+                Pair.of(4, 40)
+            ));
+
+    ListDataSink<Pair<Integer, Pair<String, Integer>>> output = ListDataSink.get();
+
+    BinaryFunctor<Pair<Integer, String>, Optional<Pair<Integer, Integer>>, Pair<String, Integer>>
+        joiner = (l, r, c) ->
+        c.collect(Pair.of(l.getSecond(), r.orElse(Pair.of(null, null)).getSecond()));
+
+    LeftJoin.of(flow.createInput(left), flow.createInput(right))
+        .by(Pair::getFirst, Pair::getFirst)
+        .using(joiner)
+        .output()
+        .persist(output);
+
+    BeamExecutor executor = TestUtils.createExecutor();
+    executor.execute(flow);
+
+    DatasetAssert.unorderedEquals(output.getOutputs(),
+        Pair.of(1, Pair.of("L v1", 1)), Pair.of(1, Pair.of("L v1", 10)),
+        Pair.of(1, Pair.of("L v2", 1)), Pair.of(1, Pair.of("L v2", 10)),
+
+        Pair.of(2, Pair.of("L v1", 20)), Pair.of(2, Pair.of("L v2", 20)),
+
+        Pair.of(3, Pair.of("L v1", null))
+    );
+
+  }
+
+  @Test
+  public void simpleRightJoinTest() {
+    final Flow flow = Flow.create();
+
+    ListDataSource<Pair<Integer, String>> left =
+        ListDataSource.bounded(
+            asList(
+                Pair.of(1, "L v1"), Pair.of(1, "L v2"),
+                Pair.of(2, "L v1"), Pair.of(2, "L v2"),
+                Pair.of(3, "L v1")
+            ));
+
+    ListDataSource<Pair<Integer, Integer>> right =
+        ListDataSource.bounded(
+            asList(
+                Pair.of(1, 1), Pair.of(1, 10),
+                Pair.of(2, 20),
+                Pair.of(4, 40)
+            ));
+
+    ListDataSink<Pair<Integer, Pair<String, Integer>>> output = ListDataSink.get();
+
+    BinaryFunctor<Optional<Pair<Integer, String>>, Pair<Integer, Integer>, Pair<String, Integer>>
+        joiner = (l, r, c) ->
+        c.collect(Pair.of(l.orElse(Pair.of(null, null)).getSecond(), r.getSecond()));
+
+    RightJoin.of(flow.createInput(left), flow.createInput(right))
+        .by(Pair::getFirst, Pair::getFirst)
+        .using(joiner)
+        .output()
+        .persist(output);
+
+    BeamExecutor executor = TestUtils.createExecutor();
+    executor.execute(flow);
+
+    DatasetAssert.unorderedEquals(output.getOutputs(),
+        Pair.of(1, Pair.of("L v1", 1)), Pair.of(1, Pair.of("L v1", 10)),
+        Pair.of(1, Pair.of("L v2", 1)), Pair.of(1, Pair.of("L v2", 10)),
+
+        Pair.of(2, Pair.of("L v1", 20)), Pair.of(2, Pair.of("L v2", 20)),
+
+        Pair.of(4, Pair.of(null, 40))
+    );
+
+  }
+
+  @Test
+  public void simpleFullJoinTest() {
+    final Flow flow = Flow.create();
+
+    ListDataSource<Pair<Integer, String>> left =
+        ListDataSource.bounded(
+            asList(
+                Pair.of(1, "L v1"), Pair.of(1, "L v2"),
+                Pair.of(2, "L v1"), Pair.of(2, "L v2"),
+                Pair.of(3, "L v1")
+            ));
+
+    ListDataSource<Pair<Integer, Integer>> right =
+        ListDataSource.bounded(
+            asList(
+                Pair.of(1, 1), Pair.of(1, 10),
+                Pair.of(2, 20),
+                Pair.of(4, 40)
+            ));
+
+    ListDataSink<Pair<Integer, Pair<String, Integer>>> output = ListDataSink.get();
+
+    BinaryFunctor<
+        Optional<Pair<Integer, String>>, Optional<Pair<Integer, Integer>>, Pair<String, Integer>>
+        joiner = (l, r, c) -> c.collect(Pair.of(
+        l.orElse(Pair.of(null, null)).getSecond(), r.orElse(Pair.of(null, null)).getSecond()));
+
+    FullJoin.of(flow.createInput(left), flow.createInput(right))
+        .by(Pair::getFirst, Pair::getFirst)
+        .using(joiner)
+        .output()
+        .persist(output);
+
+    BeamExecutor executor = TestUtils.createExecutor();
+    executor.execute(flow);
+
+    DatasetAssert.unorderedEquals(output.getOutputs(),
+        Pair.of(1, Pair.of("L v1", 1)), Pair.of(1, Pair.of("L v1", 10)),
+        Pair.of(1, Pair.of("L v2", 1)), Pair.of(1, Pair.of("L v2", 10)),
+
+        Pair.of(2, Pair.of("L v1", 20)), Pair.of(2, Pair.of("L v2", 20)),
+
+        Pair.of(3, Pair.of("L v1", null)),
+        Pair.of(4, Pair.of(null, 40))
+    );
+
+  }
+  
 }

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/test/java/cz/seznam/euphoria/beam/ReduceByKeyTest.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/test/java/cz/seznam/euphoria/beam/ReduceByKeyTest.java
@@ -43,11 +43,8 @@ import cz.seznam.euphoria.core.client.type.TypeHint;
 import cz.seznam.euphoria.core.client.util.Pair;
 import cz.seznam.euphoria.core.client.util.Sums;
 import cz.seznam.euphoria.testing.DatasetAssert;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
-import org.apache.beam.sdk.options.PipelineOptions;
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.transforms.windowing.AfterWatermark;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.values.WindowingStrategy.AccumulationMode;
@@ -58,12 +55,6 @@ import org.junit.Test;
  * Simple test suite for RBK.
  */
 public class ReduceByKeyTest {
-
-  private BeamExecutor createExecutor() {
-    String[] args = {"--runner=DirectRunner"};
-    PipelineOptions options = PipelineOptionsFactory.fromArgs(args).as(PipelineOptions.class);
-    return new BeamExecutor(options).withAllowedLateness(Duration.ofHours(1));
-  }
 
   @Test
   public void testSimpleRBK() {
@@ -84,7 +75,7 @@ public class ReduceByKeyTest {
         .output()
         .persist(output);
 
-    BeamExecutor executor = createExecutor();
+    BeamExecutor executor = TestUtils.createExecutor();
     executor.execute(flow);
 
     DatasetAssert.unorderedEquals(output.getOutputs(), Pair.of(0, 8), Pair.of(1, 7));
@@ -134,7 +125,7 @@ public class ReduceByKeyTest {
         .output()
         .persist(sink);
 
-    BeamExecutor executor = createExecutor();
+    BeamExecutor executor = TestUtils.createExecutor();
     executor.execute(flow);
 
     DatasetAssert.unorderedEquals(
@@ -203,7 +194,7 @@ public class ReduceByKeyTest {
         .output()
         .persist(sink);
 
-    createExecutor().execute(flow);
+    TestUtils.createExecutor().execute(flow);
     DatasetAssert.unorderedEquals(sink.getOutputs(), 4, 6);
   }
 

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/test/java/cz/seznam/euphoria/beam/TestUtils.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/test/java/cz/seznam/euphoria/beam/TestUtils.java
@@ -1,0 +1,17 @@
+package cz.seznam.euphoria.beam;
+
+import java.time.Duration;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+
+/**
+ * Collection of methods reused among tests.
+ */
+public class TestUtils {
+
+  static BeamExecutor createExecutor() {
+    String[] args = {"--runner=DirectRunner"};
+    PipelineOptions options = PipelineOptionsFactory.fromArgs(args).as(PipelineOptions.class);
+    return new BeamExecutor(options).withAllowedLateness(Duration.ofHours(1));
+  }
+}

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/test/java/cz/seznam/euphoria/beam/testkit/BeamExecutorProvider.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/test/java/cz/seznam/euphoria/beam/testkit/BeamExecutorProvider.java
@@ -28,6 +28,7 @@ import org.apache.beam.sdk.options.PipelineOptionsFactory;
  */
 public interface BeamExecutorProvider extends ExecutorProvider {
 
+  @Override
   default ExecutorEnvironment newExecutorEnvironment() throws Exception {
     final String[] args = {"--runner=DirectRunner"};
     final PipelineOptions options = PipelineOptionsFactory.fromArgs(args).as(PipelineOptions.class);

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/test/java/cz/seznam/euphoria/beam/testkit/BeamOperatorsSuite.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/test/java/cz/seznam/euphoria/beam/testkit/BeamOperatorsSuite.java
@@ -16,6 +16,7 @@
 package cz.seznam.euphoria.beam.testkit;
 
 import cz.seznam.euphoria.operator.test.FlatMapTest;
+import cz.seznam.euphoria.operator.test.JoinTest;
 import cz.seznam.euphoria.operator.test.UnionTest;
 import cz.seznam.euphoria.operator.test.junit.ExecutorProvider;
 import cz.seznam.euphoria.operator.test.junit.ExecutorProviderRunner;
@@ -33,7 +34,7 @@ import org.junit.runners.Suite;
     //    DistinctTest.class,
     //    FilterTest.class,
     FlatMapTest.class,
-    //    JoinTest.class,
+    JoinTest.class,
     //    JoinWindowEnforcementTest.class,
     //    MapElementsTest.class,
     //    ReduceByKeyTest.class,

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/test/java/cz/seznam/euphoria/beam/testkit/BeamOperatorsSuite.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/test/java/cz/seznam/euphoria/beam/testkit/BeamOperatorsSuite.java
@@ -17,6 +17,7 @@ package cz.seznam.euphoria.beam.testkit;
 
 import cz.seznam.euphoria.operator.test.FlatMapTest;
 import cz.seznam.euphoria.operator.test.JoinTest;
+import cz.seznam.euphoria.operator.test.ReduceByKeyTest;
 import cz.seznam.euphoria.operator.test.UnionTest;
 import cz.seznam.euphoria.operator.test.junit.ExecutorProvider;
 import cz.seznam.euphoria.operator.test.junit.ExecutorProviderRunner;
@@ -37,7 +38,7 @@ import org.junit.runners.Suite;
     JoinTest.class,
     //    JoinWindowEnforcementTest.class,
     //    MapElementsTest.class,
-    //    ReduceByKeyTest.class,
+    ReduceByKeyTest.class,
     //    ReduceStateByKeyTest.class,
     //    SumByKeyTest.class,
     //    TopPerKeyTest.class,

--- a/sdks/java/extensions/euphoria/euphoria-operator-testkit/build.gradle
+++ b/sdks/java/extensions/euphoria/euphoria-operator-testkit/build.gradle
@@ -5,5 +5,6 @@ description = "Apache Beam :: SDKs :: Java :: Extensions :: Euphoria Java 8 DSL"
 
 dependencies {
     compile project(':beam-sdks-java-extensions-euphoria-core')
+    compile project(':beam-sdks-java-extensions-euphoria-beam')
     compileOnly library.java.junit
 }

--- a/sdks/java/extensions/euphoria/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/JoinTest.java
+++ b/sdks/java/extensions/euphoria/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/JoinTest.java
@@ -17,12 +17,10 @@ package cz.seznam.euphoria.operator.test;
 
 import static org.junit.Assert.assertEquals;
 
+import cz.seznam.euphoria.beam.io.KryoCoder;
+import cz.seznam.euphoria.beam.window.BeamWindowing;
 import cz.seznam.euphoria.core.client.dataset.Dataset;
-import cz.seznam.euphoria.core.client.dataset.windowing.Session;
-import cz.seznam.euphoria.core.client.dataset.windowing.Time;
 import cz.seznam.euphoria.core.client.dataset.windowing.TimeInterval;
-import cz.seznam.euphoria.core.client.dataset.windowing.WindowedElement;
-import cz.seznam.euphoria.core.client.dataset.windowing.Windowing;
 import cz.seznam.euphoria.core.client.flow.Flow;
 import cz.seznam.euphoria.core.client.io.Collector;
 import cz.seznam.euphoria.core.client.io.ListDataSource;
@@ -32,23 +30,36 @@ import cz.seznam.euphoria.core.client.operator.Join;
 import cz.seznam.euphoria.core.client.operator.LeftJoin;
 import cz.seznam.euphoria.core.client.operator.MapElements;
 import cz.seznam.euphoria.core.client.operator.RightJoin;
-import cz.seznam.euphoria.core.client.triggers.NoopTrigger;
-import cz.seznam.euphoria.core.client.triggers.Trigger;
-import cz.seznam.euphoria.core.client.util.Either;
 import cz.seznam.euphoria.core.client.util.Pair;
 import cz.seznam.euphoria.core.client.util.Triple;
 import cz.seznam.euphoria.operator.test.accumulators.SnapshotProvider;
 import cz.seznam.euphoria.operator.test.junit.AbstractOperatorTest;
 import cz.seznam.euphoria.operator.test.junit.Processing;
-import java.time.Duration;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.transforms.windowing.AfterWatermark;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.transforms.windowing.Sessions;
+import org.apache.beam.sdk.transforms.windowing.WindowFn;
+import org.apache.beam.sdk.transforms.windowing.WindowMappingFn;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.WindowingStrategy.AccumulationMode;
+import org.joda.time.Instant;
+import org.junit.Ignore;
 import org.junit.Test;
 
-/** Test operator {@code Join}. */
+/**
+ * Test operator {@code Join}.
+ */
 @Processing(Processing.Type.ALL)
 public class JoinTest extends AbstractOperatorTest {
 
@@ -269,7 +280,10 @@ public class JoinTest extends AbstractOperatorTest {
                     (Optional<Integer> l, Optional<Long> r, Collector<String> c) -> {
                       c.collect(l.orElse(null) + "+" + r.orElse(null));
                     })
-                .windowBy(new EvenOddWindowing())
+                .windowBy(BeamWindowing.of(
+                    new EvenOddWindowFn(),
+                    AfterWatermark.pastEndOfWindow(),
+                    AccumulationMode.DISCARDING_FIRED_PANES))
                 .output();
           }
 
@@ -319,7 +333,10 @@ public class JoinTest extends AbstractOperatorTest {
                     (Integer l, Optional<Long> r, Collector<String> c) -> {
                       c.collect(l + "+" + r.orElse(null));
                     })
-                .windowBy(new EvenOddWindowing())
+                .windowBy(BeamWindowing.of(
+                    new EvenOddWindowFn(),
+                    AfterWatermark.pastEndOfWindow(),
+                    AccumulationMode.DISCARDING_FIRED_PANES))
                 .output();
           }
 
@@ -364,7 +381,10 @@ public class JoinTest extends AbstractOperatorTest {
                     (Optional<Integer> l, Long r, Collector<String> c) -> {
                       c.collect(l.orElse(null) + "+" + r);
                     })
-                .windowBy(new EvenOddWindowing())
+                .windowBy(BeamWindowing.of(
+                    new EvenOddWindowFn(),
+                    AfterWatermark.pastEndOfWindow(),
+                    AccumulationMode.DISCARDING_FIRED_PANES))
                 .output();
           }
 
@@ -401,7 +421,7 @@ public class JoinTest extends AbstractOperatorTest {
   public void joinOnSessionWindowingNoEarlyTriggering() {
     execute(
         new JoinTestCase<
-            Pair<String, Long>, Pair<String, Long>, Triple<TimeInterval, String, String>>() {
+            Pair<String, Long>, Pair<String, Long>, Pair<String, String>>() {
 
           @Override
           protected List<Pair<String, Long>> getLeftInput() {
@@ -414,37 +434,41 @@ public class JoinTest extends AbstractOperatorTest {
           }
 
           @Override
-          protected Dataset<Triple<TimeInterval, String, String>> getOutput(
+          protected Dataset<Pair<String, String>> getOutput(
               Dataset<Pair<String, Long>> left, Dataset<Pair<String, Long>> right) {
+
             left = AssignEventTime.of(left).using(Pair::getSecond).output();
             right = AssignEventTime.of(right).using(Pair::getSecond).output();
-            Dataset<Pair<String, Triple<TimeInterval, String, String>>> joined =
+
+            Dataset<Pair<String, Pair<String, String>>> joined =
                 Join.of(left, right)
                     .by(p -> "", p -> "")
                     .using(
-                        (Pair<String, Long> l,
-                            Pair<String, Long> r,
-                            Collector<Triple<TimeInterval, String, String>> c) ->
-                            c.collect(
-                                Triple.of(
-                                    (TimeInterval) c.getWindow(), l.getFirst(), r.getFirst())))
-                    .windowBy(Session.of(Duration.ofMillis(10)))
+                        (Pair<String, Long> l, Pair<String, Long> r,
+                            Collector<Pair<String, String>> c) ->
+                            c.collect(Pair.of(l.getFirst(), r.getFirst())))
+                    .windowBy(BeamWindowing.of(
+                        Sessions.withGapDuration(org.joda.time.Duration.millis(10)),
+                        AfterWatermark.pastEndOfWindow(),
+                        AccumulationMode.DISCARDING_FIRED_PANES))
                     .output();
             return MapElements.of(joined).using(Pair::getSecond).output();
           }
 
           @Override
-          public List<Triple<TimeInterval, String, String>> getUnorderedOutput() {
-            TimeInterval expectedWindow = new TimeInterval(1, 14);
+          public List<Pair<String, String>> getUnorderedOutput() {
             return Arrays.asList(
-                Triple.of(expectedWindow, "fi", "ha"),
-                Triple.of(expectedWindow, "fi", "ho"),
-                Triple.of(expectedWindow, "fa", "ha"),
-                Triple.of(expectedWindow, "fa", "ho"));
+                Pair.of("fi", "ha"),
+                Pair.of("fi", "ho"),
+                Pair.of("fa", "ha"),
+                Pair.of("fa", "ho"));
           }
         });
   }
 
+  @Ignore(
+      "This test is based on access to various objects through Environment which is "
+          + "unsupported feature. It may be possible to add this feature in future.")
   @Test
   public void testJoinAccumulators() {
     execute(
@@ -464,8 +488,10 @@ public class JoinTest extends AbstractOperatorTest {
           @Override
           protected Dataset<Triple<TimeInterval, String, String>> getOutput(
               Dataset<Pair<String, Long>> left, Dataset<Pair<String, Long>> right) {
+
             left = AssignEventTime.of(left).using(Pair::getSecond).output();
             right = AssignEventTime.of(right).using(Pair::getSecond).output();
+
             Dataset<Pair<String, Triple<TimeInterval, String, String>>> joined =
                 Join.of(left, right)
                     .by(p -> "", p -> "")
@@ -478,7 +504,11 @@ public class JoinTest extends AbstractOperatorTest {
                           c.getHistogram("hist-" + l.getFirst().charAt(1)).add(2345, 8);
                           c.collect(Triple.of(window, l.getFirst(), r.getFirst()));
                         })
-                    .windowBy(Time.of(Duration.ofMillis(3)))
+//                    .windowBy(Time.of(Duration.ofMillis(3)))
+                    .windowBy(BeamWindowing.of(
+                        FixedWindows.of(org.joda.time.Duration.millis(3)),
+                        AfterWatermark.pastEndOfWindow(),
+                        AccumulationMode.DISCARDING_FIRED_PANES))
                     .output();
             return MapElements.of(joined).using(Pair::getSecond).output();
           }
@@ -509,11 +539,9 @@ public class JoinTest extends AbstractOperatorTest {
 
   /**
    * Base for join test cases.
-   * @param <LeftT>
-   * @param <RightT>
-   * @param <OutputT>
    */
   public abstract static class JoinTestCase<LeftT, RightT, OutputT> implements TestCase<OutputT> {
+
     @Override
     public Dataset<OutputT> getOutput(Flow flow, boolean bounded) {
       Dataset<LeftT> left = flow.createInput(ListDataSource.of(bounded, getLeftInput()));
@@ -528,36 +556,87 @@ public class JoinTest extends AbstractOperatorTest {
     protected abstract List<RightT> getRightInput();
   }
 
-  /** Stable windowing for test purposes. */
-  static class EvenOddWindowing implements Windowing<Either<Integer, Long>, IntWindow> {
+
+  /**
+   * Elements with even numeric values are are assigned to one 'even' window. All others are
+   * assigned to window named 'win: #', where '#' is value of assigned element.
+   */
+  private static class EvenOddWindowFn extends WindowFn<KV<Integer, Number>, BoundedWindow> {
+
+    private static final NamedGlobalWindow EVEN_WIN = new NamedGlobalWindow("even");
 
     @Override
-    public Iterable<IntWindow> assignWindowsToElement(
-        WindowedElement<?, Either<Integer, Long>> input) {
-      int element;
-      Either<Integer, Long> unwrapped = input.getElement();
-      if (unwrapped.isLeft()) {
-        element = unwrapped.left();
-      } else {
-        element = (int) (long) unwrapped.right();
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
+    public Collection<BoundedWindow> assignWindows(AssignContext c) throws Exception {
+      KV<Integer, Number> element = c.element();
+
+      Number value = element.getValue();
+
+      if (value == null) {
+        return Collections.singleton(EVEN_WIN);
       }
-      final int label = element % 2 == 0 ? 0 : element;
-      return Collections.singleton(new IntWindow(label));
+
+      NamedGlobalWindow win;
+      if (value.longValue() % 2 == 0) {
+        win = EVEN_WIN;
+      } else {
+        win = new NamedGlobalWindow("win: " + value.longValue());
+      }
+
+      return Collections.singleton(win);
     }
 
     @Override
-    public Trigger<IntWindow> getTrigger() {
-      return NoopTrigger.get();
+    public void mergeWindows(MergeContext c) throws Exception {
+      // no merging
     }
 
     @Override
-    public boolean equals(Object obj) {
-      return obj instanceof EvenOddWindowing;
+    public boolean isCompatible(WindowFn<?, ?> other) {
+      return other instanceof EvenOddWindowFn;
+    }
+
+    @Override
+    public Coder<BoundedWindow> windowCoder() {
+      return new KryoCoder<>();
+    }
+
+    @Override
+    @Nullable
+    public WindowMappingFn<BoundedWindow> getDefaultWindowMappingFn() {
+      return null;
+    }
+
+    @Override
+    public boolean isNonMerging() {
+      return true;
+    }
+  }
+
+  private static class NamedGlobalWindow extends BoundedWindow {
+
+    private String name;
+
+    public NamedGlobalWindow(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public Instant maxTimestamp() {
+      return GlobalWindow.INSTANCE.maxTimestamp();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (other instanceof NamedGlobalWindow) {
+        return name.equals(((NamedGlobalWindow) other).name);
+      }
+      return false;
     }
 
     @Override
     public int hashCode() {
-      return 0;
+      return name.hashCode();
     }
   }
 }

--- a/sdks/java/extensions/euphoria/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/ReduceByKeyTest.java
+++ b/sdks/java/extensions/euphoria/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/ReduceByKeyTest.java
@@ -61,8 +61,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.transforms.windowing.AfterWatermark;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
@@ -76,11 +78,15 @@ import org.joda.time.Instant;
 import org.junit.Ignore;
 import org.junit.Test;
 
-/** Test operator {@code ReduceByKey}. */
+/**
+ * Test operator {@code ReduceByKey}.
+ */
 @Processing(Processing.Type.ALL)
 public class ReduceByKeyTest extends AbstractOperatorTest {
 
-  /** Validates the output type upon a `.reduceBy` operation on global window. */
+  /**
+   * Validates the output type upon a `.reduceBy` operation on global window.
+   */
   @Test
   public void testReductionType0() {
     execute(
@@ -112,7 +118,9 @@ public class ReduceByKeyTest extends AbstractOperatorTest {
         });
   }
 
-  /** Validates the output type upon a `.reduceBy` operation on global window. */
+  /**
+   * Validates the output type upon a `.reduceBy` operation on global window.
+   */
   @Test
   public void testReductionType0_outputValues() {
     execute(
@@ -143,7 +151,9 @@ public class ReduceByKeyTest extends AbstractOperatorTest {
         });
   }
 
-  /** Validates the output type upon a `.reduceBy` operation on global window. */
+  /**
+   * Validates the output type upon a `.reduceBy` operation on global window.
+   */
   @Ignore("Sorting of values is not supported yet.")
   @Test
   public void testReductionType0WithSortedValues() {
@@ -203,7 +213,9 @@ public class ReduceByKeyTest extends AbstractOperatorTest {
         });
   }
 
-  /** Validates the output type upon a `.reduceBy` operation on windows of size one. */
+  /**
+   * Validates the output type upon a `.reduceBy` operation on windows of size one.
+   */
   @Test
   public void testReductionType0MultiValues() {
     execute(
@@ -463,6 +475,7 @@ public class ReduceByKeyTest extends AbstractOperatorTest {
         });
   }
 
+  @Ignore("Test adaption to Beam windowing failed so far.")
   @Test
   public void testMergingAndTriggering() {
     execute(
@@ -472,14 +485,14 @@ public class ReduceByKeyTest extends AbstractOperatorTest {
           protected List<Pair<String, Long>> getInput() {
             return Arrays.asList(
                 Pair.of("a", 20L),
-                Pair.of("c", 3000L),
+                Pair.of("c", 3_000L),
                 Pair.of("b", 10L),
                 Pair.of("b", 100L),
-                Pair.of("a", 4000L),
+                Pair.of("a", 4_000L),
                 Pair.of("c", 300L),
-                Pair.of("b", 1000L),
-                Pair.of("b", 50000L),
-                Pair.of("a", 100000L),
+                Pair.of("b", 1_000L),
+                Pair.of("b", 50_000L),
+                Pair.of("a", 100_000L),
                 Pair.of("a", 800L),
                 Pair.of("a", 80L));
           }
@@ -490,7 +503,11 @@ public class ReduceByKeyTest extends AbstractOperatorTest {
                 .keyBy(Pair::getFirst)
                 .valueBy(Pair::getSecond)
                 .combineBy(Sums.ofLongs())
-                .windowBy(new CWindowing<>(3))
+//                .windowBy(new CWindowing<>(3))
+                .windowBy(BeamWindowing.of(
+                    new MergingByBucketSizeWindowFn<>(3),
+                    AfterWatermark.pastEndOfWindow(),
+                    AccumulationMode.DISCARDING_FIRED_PANES))
                 .output();
           }
 
@@ -499,10 +516,10 @@ public class ReduceByKeyTest extends AbstractOperatorTest {
           public List<Pair<String, Long>> getUnorderedOutput() {
             return Arrays.asList(
                 Pair.of("a", 880L),
-                Pair.of("a", 104020L),
-                Pair.of("b", 1110L),
-                Pair.of("b", 50000L),
-                Pair.of("c", 3300L));
+                Pair.of("a", 104_020L),
+                Pair.of("b", 1_110L),
+                Pair.of("b", 50_000L),
+                Pair.of("c", 3_300L));
           }
         });
   }
@@ -546,7 +563,7 @@ public class ReduceByKeyTest extends AbstractOperatorTest {
             return FlatMap.of(reduced)
                 .using(
                     (UnaryFunctor<
-                            Pair<Integer, Set<String>>, Triple<TimeInterval, Integer, Set<String>>>)
+                        Pair<Integer, Set<String>>, Triple<TimeInterval, Integer, Set<String>>>)
                         (elem, context) ->
                             context.collect(
                                 Triple.of(
@@ -576,7 +593,7 @@ public class ReduceByKeyTest extends AbstractOperatorTest {
   @Test
   public void testElementTimestamp() {
 
-    class AssertingWindowFn<T> extends WindowFn<T, BoundedWindow>{
+    class AssertingWindowFn<T> extends WindowFn<T, BoundedWindow> {
 
       @Override
       public Collection<BoundedWindow> assignWindows(AssignContext c) throws Exception {
@@ -603,10 +620,11 @@ public class ReduceByKeyTest extends AbstractOperatorTest {
 
       @Override
       public Coder<BoundedWindow> windowCoder() {
-        return new KryoCoder<>(); //TODO do we need this?
+        return new KryoCoder<>();
       }
 
       @Override
+      @Nullable
       public WindowMappingFn<BoundedWindow> getDefaultWindowMappingFn() {
         return null;
       }
@@ -784,12 +802,12 @@ public class ReduceByKeyTest extends AbstractOperatorTest {
     }
   }
 
-  private static class TestWindowFn extends WindowFn<Number, CountWindow>{
+  private static class TestWindowFn extends WindowFn<Number, CountWindow> {
 
     @Override
     public Collection<CountWindow> assignWindows(AssignContext c) throws Exception {
       Number element = c.element();
-      return Collections.singleton(new CountWindow(element.longValue() / 4 )); //TODO why /4 ?
+      return Collections.singleton(new CountWindow(element.longValue() / 4));
     }
 
     @Override
@@ -813,6 +831,7 @@ public class ReduceByKeyTest extends AbstractOperatorTest {
     }
 
     @Override
+    @Nullable
     public WindowMappingFn<CountWindow> getDefaultWindowMappingFn() {
       return null;
     }
@@ -844,6 +863,37 @@ public class ReduceByKeyTest extends AbstractOperatorTest {
     @Override
     public int hashCode() {
       return Long.hashCode(value);
+    }
+  }
+
+  private static class UniqueWindow extends BoundedWindow {
+
+    private static final AtomicInteger idCounter = new AtomicInteger();
+    private final int id;
+
+    public UniqueWindow() {
+      this.id = idCounter.getAndIncrement();
+    }
+
+    @Override
+    public Instant maxTimestamp() {
+      return GlobalWindow.INSTANCE.maxTimestamp();
+    }
+
+    @Override
+    public int hashCode() {
+      return Integer.hashCode(id);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj instanceof UniqueWindow
+          && this.id == ((UniqueWindow) obj).id;
+    }
+
+    @Override
+    public String toString() {
+      return "UniqueWindow{id=" + id + "}";
     }
   }
 
@@ -891,6 +941,7 @@ public class ReduceByKeyTest extends AbstractOperatorTest {
 
   // count windowing; firing based on window.bucket (size of the window)
   static final class CWindowTrigger implements Trigger<CWindow> {
+
     private final ValueStorageDescriptor<Long> countDesc =
         ValueStorageDescriptor.of("count", Long.class, 0L, (x, y) -> x + y);
 
@@ -920,7 +971,62 @@ public class ReduceByKeyTest extends AbstractOperatorTest {
     }
   }
 
+  private static class MergingByBucketSizeWindowFn<T> extends WindowFn<T, UniqueWindow> {
+
+    private final int bucketSize;
+
+    private MergingByBucketSizeWindowFn(int bucketSize) {
+      this.bucketSize = bucketSize;
+    }
+
+    @Override
+    public Collection<UniqueWindow> assignWindows(AssignContext c) throws Exception {
+      return Collections.singleton(new UniqueWindow());
+    }
+
+    @Override
+    public void mergeWindows(MergeContext c) throws Exception {
+
+//       merge windows up to bucket size
+      Collection<UniqueWindow> windows = c.windows();
+      List<UniqueWindow> merges = new ArrayList<>();
+      for (UniqueWindow w : windows) {
+
+        merges.add(w);
+
+        if (merges.size() == bucketSize) { // time to merge
+          c.merge(merges, w);
+          merges.clear();
+        }
+
+      }
+
+      if (merges.size() > 1) {
+        c.merge(merges, merges.get(merges.size() - 1));
+      }
+
+    }
+
+    @Override
+    public boolean isCompatible(WindowFn<?, ?> other) {
+      return other instanceof MergingByBucketSizeWindowFn
+          && this.bucketSize == ((MergingByBucketSizeWindowFn) other).bucketSize;
+    }
+
+    @Override
+    public Coder<UniqueWindow> windowCoder() {
+      return new KryoCoder<>();
+    }
+
+    @Override
+    @Nullable
+    public WindowMappingFn<UniqueWindow> getDefaultWindowMappingFn() {
+      return null;
+    }
+  }
+
   static final class CWindowing<T> implements MergingWindowing<T, CWindow> {
+
     private final int size;
 
     CWindowing(int size) {
@@ -969,6 +1075,7 @@ public class ReduceByKeyTest extends AbstractOperatorTest {
   }
 
   static class SumState implements State<Integer, Integer> {
+
     private final ValueStorage<Integer> sum;
 
     SumState(StateContext context, Collector<Integer> collector) {
@@ -1000,7 +1107,9 @@ public class ReduceByKeyTest extends AbstractOperatorTest {
     }
   }
 
-  /** String with invalid hash code implementation returning constant. */
+  /**
+   * String with invalid hash code implementation returning constant.
+   */
   public static class Word {
 
     private final String str;


### PR DESCRIPTION
Existing tests suit for `ReduceByKey` Euphoria operator was adapted for current state of Beam integration. Some tests are ignored due to not yet supported features. 

There are still some open points:
* Flipping test. When whole test suit runs some test may randomly fail. Assertion error shows empty test output. Current believe is that we may have a problem somewhere around `ListDataSink` due to a race condition. We should address that in https://issues.apache.org/jira/browse/BEAM-4366.
* Sorting of values. It is not yet clear how to implement this feature in beam.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [X] Write a pull request description that is detailed enough to understand:
   - [X] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Run `./gradlew build` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

